### PR TITLE
Reformat all code with ormolu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,13 @@ stop:
 
 prune: stop
 	docker volume rm haskellstarterkit_pg-data
+
+ORMOLU_VERSION = 0.1.4.1
+ORMOLU_OPTIONS = --mode inplace --check-idempotence
+
+style:
+	@ROOT=$$(git rev-parse --show-toplevel) && \
+		cd "$$ROOT" && \
+		FMT=$$(stack exec --package ormolu-'$(ORMOLU_VERSION)' which ormolu) && \
+		find src app test -type f -name \*.hs -exec \
+			"$$FMT" $(ORMOLU_OPTIONS) '{}' +

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ make run
 
 ## Develop with stack
 
+To format source code, use:
+
+`make style`
+
+We use a specific version of the ormolu formatter. It will be installed
+automatically for the first time into an internal location using stack. It will
+not overwrite your locally installed ormolu version in `~/.stack/bin`.
+
 To build project:
 
 `stack build`

--- a/src/AppName/AppHandle.hs
+++ b/src/AppName/AppHandle.hs
@@ -19,12 +19,11 @@ import Database.Persist.Sql (SqlBackend)
 import qualified Ext.Logger.Colog as Log
 import Ext.Logger.Config (LoggerConfig)
 
-data AppHandle
-  = AppHandle
-      { appHandleDbPool :: Pool SqlBackend,
-        appHandleConfig :: C.Config,
-        appHandleLogger :: LoggerConfig
-      }
+data AppHandle = AppHandle
+  { appHandleDbPool :: Pool SqlBackend,
+    appHandleConfig :: C.Config,
+    appHandleLogger :: LoggerConfig
+  }
 
 type MonadHandler m = (MonadIO m, Log.WithLog (Log.LogAction m Log.Message) Log.Message m)
 

--- a/src/Ext/HTTP/Error.hs
+++ b/src/Ext/HTTP/Error.hs
@@ -2,16 +2,17 @@
 
 module Ext.HTTP.Error where
 
-import qualified Data.Aeson as J
 import Data.Aeson ((.=))
+import qualified Data.Aeson as J
 import Data.Maybe (maybeToList)
 import qualified Data.Text as T
 
 data WebApiHttpError = WebApiHttpError
-  { waheMessage :: T.Text
-  , waheCode :: T.Text
-  , waheData :: Maybe J.Value
-  } deriving (Show, Eq)
+  { waheMessage :: T.Text,
+    waheCode :: T.Text,
+    waheData :: Maybe J.Value
+  }
+  deriving (Show, Eq)
 
 instance J.ToJSON WebApiHttpError where
   toJSON WebApiHttpError {..} =


### PR DESCRIPTION
Отформатировал все исходники и сделал команду `make style` для использования правильного форматтера. Версия форматтера зафиксирована, от предустановленного форматтера мы не зависим - он поставится при необходимости в правильной версии, ничего нигде не затрет.
