### PR TITLE
Fix #16: could not run migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ stop:
 	docker-compose down
 
 prune: stop
-	docker volume rm haskellstarterkit_pg-data
+	docker volume rm haskell-starter-kit_pg-data
 
 style:
 	@cd "$$(git rev-parse --show-toplevel)" && ./scripts/format-code

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To configure env for project:
 
 `cp ./.env.template ./.env`
 
+3. Configure liquibase at `migrations/liquibase.properties` using template at
+   `migrations/liquibase.template.properties`:
+
+`cp migrations/liquibase.template.properties migrations/liquibase.properties`
+
 ## Run with docker
 
 You need to have docker installed in your system. Then run:
@@ -22,6 +27,9 @@ You need to have docker installed in your system. Then run:
 make deps
 make run
 ```
+
+`make run` is needed every time you'd like to build and run the project in a
+docker container. `make deps` is only rarely needed when `make run` fails.
 
 ## Develop with stack
 
@@ -37,7 +45,7 @@ To build project:
 
 `stack build`
 
-To run migration:
+To run migration, ensure you have run `make run` and run the command:
 
 `./migration/run.sh`
 

--- a/migrations/liquibase.template.properties
+++ b/migrations/liquibase.template.properties
@@ -1,6 +1,6 @@
 classpath: /opt/jdbc/postgres-jdbc.jar
 driver: org.postgresql.Driver
-url: jdbc:postgresql://host.docker.internal:5432/appnamedb
+url: jdbc:postgresql://localhost:5431/appnamedb
 username: myuser
 password: mypass
 changeLogFile: changelog.xml

--- a/migrations/run.sh
+++ b/migrations/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
+
 docker run \
     --network="host" \
-    -v `pwd`/migrations:/workspace/ \
+    -v "$(pwd)"/migrations:/workspace/ \
     kilna/liquibase-postgres \
     liquibase update


### PR DESCRIPTION
- добавил в README указание создать `liquibase.properties`
- исправил порт в `liquibase.template.properties` - без этого liquibase не коннектится к постгресу, "Connection refused"
- дополнил скрипт `migrations/run.sh` вариантом запуска для линукса.