### PR TITLE
Optimize Dockerfile.deps for build step caching

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,10 +1,9 @@
 # starterkit/dependencies:latest
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl libghc-postgresql-libpq-dev
 RUN curl -sSL https://get.haskellstack.org/ | sh
-
-RUN apt-get install -y libghc-postgresql-libpq-dev
+RUN stack update
 
 COPY ./ haskell-starter-kit/
 


### PR DESCRIPTION
`stack update` now updates package index database before copying the project
files into the container. The new step is cached by docker so that it speeds up
the `stack setup` step and rebuilding the container.