### PR TITLE
Isolate from logger

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -77,6 +77,7 @@ ghc-options:
 
 default-extensions:
 - RecordWildCards
+- NamedFieldPuns
 - OverloadedStrings
 - FlexibleContexts
 - FlexibleInstances
@@ -86,6 +87,7 @@ default-extensions:
 - TypeOperators
 - DeriveGeneric
 - MonoLocalBinds
+- LambdaCase
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name:                haskell-starter-kit
 version:             0.1.0.0
-github:              "githubuser/haskell-starter-kit"
+github:              "fullstack-development/haskell-starter-kit"
 license:             BSD3
 author:              "Author name here"
 maintainer:          "example@example.com"

--- a/src/AppName/AppHandle.hs
+++ b/src/AppName/AppHandle.hs
@@ -17,7 +17,7 @@ import Control.Monad.IO.Unlift (MonadIO)
 import Control.Monad.Logger (NoLoggingT)
 import Data.Pool (Pool)
 import Database.Persist.Sql (SqlBackend)
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger as Log
 import Ext.Logger.Config (LoggerConfig)
 
 data AppHandle = AppHandle
@@ -27,7 +27,7 @@ data AppHandle = AppHandle
     appHandleRandomGen :: CryptoRandomGen.Ref
   }
 
-type MonadHandler m = (MonadIO m, Log.WithLog (Log.LogAction m Log.Message) Log.Message m)
+type MonadHandler m = (MonadIO m, Log.WithLog m)
 
 withAppHandle :: (AppHandle -> NoLoggingT IO b) -> IO b
 withAppHandle action = do

--- a/src/AppName/Auth/Combinators.hs
+++ b/src/AppName/Auth/Combinators.hs
@@ -9,11 +9,11 @@ import Control.Exception.Safe (MonadThrow, throw)
 import Control.Monad.IO.Class
 import qualified Data.Text as T
 import Ext.Data.Text (tshow)
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger as Log
 import Servant (err404)
 
 withClient ::
-  (Log.WithLog env Log.Message m, MonadIO m, MonadThrow m) =>
+  (Log.WithLog m, MonadIO m, MonadThrow m) =>
   T.Text ->
   AuthenticatedUser ->
   (Int -> m a) ->
@@ -23,7 +23,7 @@ withClient handlerName user _ =
   logUnexpectedActor "client" user handlerName >> throw err404
 
 withAdmin ::
-  (Log.WithLog env Log.Message m, MonadIO m, MonadThrow m) =>
+  (Log.WithLog m, MonadIO m, MonadThrow m) =>
   T.Text ->
   AuthenticatedUser ->
   (Int -> m a) ->
@@ -32,9 +32,9 @@ withAdmin _ (AuthenticatedAdmin adminId) handler = handler adminId
 withAdmin handlerName user _ =
   logUnexpectedActor "client" user handlerName >> throw err404
 
-logUnexpectedActor :: (Log.WithLog env Log.Message m, Show a) => T.Text -> a -> T.Text -> m ()
+logUnexpectedActor :: (Log.WithLog m, Show a) => T.Text -> a -> T.Text -> m ()
 logUnexpectedActor expected actual source =
-  Log.logError $
+  Log.error $
     "Expected " <> expected <> " role, but got " <> tshow actual
       <> " while invoking handler "
       <> source

--- a/src/AppName/Auth/Combinators.hs
+++ b/src/AppName/Auth/Combinators.hs
@@ -34,7 +34,7 @@ withAdmin handlerName user _ =
 
 logUnexpectedActor :: (Log.WithLog m, Show a) => T.Text -> a -> T.Text -> m ()
 logUnexpectedActor expected actual source =
-  Log.error $
+  Log.logError $
     "Expected " <> expected <> " role, but got " <> tshow actual
       <> " while invoking handler "
       <> source

--- a/src/AppName/Config.hs
+++ b/src/AppName/Config.hs
@@ -14,7 +14,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.Configurator as C
 import qualified Data.Configurator.Types as C
 import Data.Maybe (fromMaybe)
-import Ext.Logger.Colog (Severity (Debug))
+import qualified Ext.Logger as Log
 import Ext.Logger.Config (LoggerConfig (..))
 import Text.Read (readMaybe)
 
@@ -43,5 +43,5 @@ getLoggerConfig config = liftIO $ do
     LoggerConfig
       { appInstanceName = appInstanceName,
         logToStdout = logToStdout,
-        logLevel = fromMaybe Debug (readMaybe logLevelRaw)
+        logLevel = fromMaybe Log.Debug (readMaybe logLevelRaw)
       }

--- a/src/AppName/Gateways/Endpoints/FakeLogin.hs
+++ b/src/AppName/Gateways/Endpoints/FakeLogin.hs
@@ -61,5 +61,5 @@ fakeLoginEndpoint jwtSettings (LoginData userId "Open Sesame") = do
         Nothing
   either (pure . LoginResponseError) (pure . LoginResponseSuccess) token
 fakeLoginEndpoint _ _ = do
-  Log.error "fakeLoginEndpoint: Unauthorized access"
+  Log.logError "fakeLoginEndpoint: Unauthorized access"
   liftIO $ throw err401

--- a/src/AppName/Gateways/Endpoints/FakeLogin.hs
+++ b/src/AppName/Gateways/Endpoints/FakeLogin.hs
@@ -16,7 +16,7 @@ import Data.Aeson ((.=))
 import qualified Data.Aeson as J
 import qualified Data.ByteString.Lazy as BL
 import qualified Ext.Data.Aeson as J
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger as Log
 import GHC.Generics (Generic)
 import Servant (err401)
 import qualified Servant.Auth.Server as SAS
@@ -61,5 +61,5 @@ fakeLoginEndpoint jwtSettings (LoginData userId "Open Sesame") = do
         Nothing
   either (pure . LoginResponseError) (pure . LoginResponseSuccess) token
 fakeLoginEndpoint _ _ = do
-  Log.logError "fakeLoginEndpoint: Unauthorized access"
+  Log.error "fakeLoginEndpoint: Unauthorized access"
   liftIO $ throw err401

--- a/src/AppName/Gateways/Endpoints/GetUsers.hs
+++ b/src/AppName/Gateways/Endpoints/GetUsers.hs
@@ -21,7 +21,7 @@ import AppName.Gateways.Database
 import Control.Exception.Safe (throw)
 import Control.Monad.IO.Unlift (MonadIO (liftIO))
 import Database.Persist.Postgresql
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger as Log
 import Servant (err401)
 import qualified Servant.Auth.Server as SAS
 
@@ -84,5 +84,5 @@ getCurrentUserEndpoint AppHandle {..} (SAS.Authenticated (AuthenticatedClient us
                     }
             }
 getCurrentUserEndpoint _ _ = do
-  Log.logError "getCurrentUserEndpoint: Unauthorized access"
+  Log.error "getCurrentUserEndpoint: Unauthorized access"
   liftIO $ throw err401

--- a/src/AppName/Gateways/Endpoints/GetUsers.hs
+++ b/src/AppName/Gateways/Endpoints/GetUsers.hs
@@ -84,5 +84,5 @@ getCurrentUserEndpoint AppHandle {..} (SAS.Authenticated (AuthenticatedClient us
                     }
             }
 getCurrentUserEndpoint _ _ = do
-  Log.error "getCurrentUserEndpoint: Unauthorized access"
+  Log.logError "getCurrentUserEndpoint: Unauthorized access"
   liftIO $ throw err401

--- a/src/AppName/Gateways/Endpoints/SaveUsers.hs
+++ b/src/AppName/Gateways/Endpoints/SaveUsers.hs
@@ -26,5 +26,5 @@ saveUserPersonalInfoEndpoint AppHandle {..} (SAS.Authenticated (AuthenticatedCli
   where
     sqlUserId = toSqlKey $ fromIntegral userId
 saveUserPersonalInfoEndpoint _ _ _ = do
-  Log.error "saveUserPersonalInfoEndpoint: Unauthorized access"
+  Log.logError "saveUserPersonalInfoEndpoint: Unauthorized access"
   liftIO $ throw err401

--- a/src/AppName/Gateways/Endpoints/SaveUsers.hs
+++ b/src/AppName/Gateways/Endpoints/SaveUsers.hs
@@ -14,7 +14,7 @@ import Control.Monad.IO.Unlift (MonadIO (liftIO))
 import Data.Functor (($>))
 import Database.Persist.Postgresql (runSqlPersistMPool, toSqlKey)
 import qualified Ext.HTTP.Response as Web
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger as Log
 import Servant (err401)
 import qualified Servant.Auth.Server as SAS
 
@@ -26,5 +26,5 @@ saveUserPersonalInfoEndpoint AppHandle {..} (SAS.Authenticated (AuthenticatedCli
   where
     sqlUserId = toSqlKey $ fromIntegral userId
 saveUserPersonalInfoEndpoint _ _ _ = do
-  Log.logError "saveUserPersonalInfoEndpoint: Unauthorized access"
+  Log.error "saveUserPersonalInfoEndpoint: Unauthorized access"
   liftIO $ throw err401

--- a/src/Ext/Logger.hs
+++ b/src/Ext/Logger.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE ConstraintKinds #-}
+
+-- The application logger interface module. This should be minimal
+-- possible and independent of a particular logging library or
+-- implementation.
+module Ext.Logger
+  ( WithLog,
+    MonadLogger (..),
+    Severity (..),
+    CallStack (..),
+    debug,
+    info,
+    warn,
+    error,
+  )
+where
+
+import qualified Data.Text as T
+import qualified GHC.Stack as GHC
+import Prelude hiding (error)
+
+-- | Use the type instead of 'MonadLogger' to pass the logger monad
+-- constraint. This is necessary to capture the caller function name
+-- within the GHC call stack.
+type WithLog m = (GHC.HasCallStack, MonadLogger m)
+
+class Monad m => MonadLogger m where
+  logMessage :: Severity -> CallStack -> T.Text -> m ()
+
+data Severity = Debug | Info | Warning | Error
+  deriving (Eq, Show, Read)
+
+newtype CallStack = CallStack {unCallStack :: GHC.CallStack}
+
+debug, info, warn, error :: (GHC.HasCallStack, MonadLogger m) => T.Text -> m ()
+debug = GHC.withFrozenCallStack $ logCapturingCallStack Debug
+info = GHC.withFrozenCallStack $ logCapturingCallStack Info
+warn = GHC.withFrozenCallStack $logCapturingCallStack Warning
+error = GHC.withFrozenCallStack $ logCapturingCallStack Error
+
+logCapturingCallStack :: (GHC.HasCallStack, MonadLogger m) => Severity -> T.Text -> m ()
+logCapturingCallStack severity = GHC.withFrozenCallStack (logMessage severity $ CallStack GHC.callStack)

--- a/src/Ext/Logger.hs
+++ b/src/Ext/Logger.hs
@@ -11,10 +11,10 @@ module Ext.Logger
     MonadLogger (..),
     Severity (..),
     CallStack (..),
-    debug,
-    info,
-    warn,
-    error,
+    logDebug,
+    logInfo,
+    logWarn,
+    logError,
   )
 where
 
@@ -37,11 +37,11 @@ newtype CallStack = CallStack {unCallStack :: GHC.CallStack}
 
 -- Yoy may use them as `Log.info`, `Log.error` etc. if you imported
 -- the module qualified with the corresponding alias.
-debug, info, warn, error :: (GHC.HasCallStack, MonadLogger m) => T.Text -> m ()
-debug = GHC.withFrozenCallStack $ logCapturingCallStack Debug
-info = GHC.withFrozenCallStack $ logCapturingCallStack Info
-warn = GHC.withFrozenCallStack $ logCapturingCallStack Warning
-error = GHC.withFrozenCallStack $ logCapturingCallStack Error
+logDebug, logInfo, logWarn, logError :: (GHC.HasCallStack, MonadLogger m) => T.Text -> m ()
+logDebug = GHC.withFrozenCallStack $ logCapturingCallStack Debug
+logInfo = GHC.withFrozenCallStack $ logCapturingCallStack Info
+logWarn = GHC.withFrozenCallStack $ logCapturingCallStack Warning
+logError = GHC.withFrozenCallStack $ logCapturingCallStack Error
 
 logCapturingCallStack :: (GHC.HasCallStack, MonadLogger m) => Severity -> T.Text -> m ()
 logCapturingCallStack severity = GHC.withFrozenCallStack (logMessage severity $ CallStack GHC.callStack)

--- a/src/Ext/Logger.hs
+++ b/src/Ext/Logger.hs
@@ -3,6 +3,9 @@
 -- The application logger interface module. This should be minimal
 -- possible and independent of a particular logging library or
 -- implementation.
+--
+-- The module is intended to be imported qualified with an alias like
+-- @Log@.
 module Ext.Logger
   ( WithLog,
     MonadLogger (..),
@@ -32,10 +35,12 @@ data Severity = Debug | Info | Warning | Error
 
 newtype CallStack = CallStack {unCallStack :: GHC.CallStack}
 
+-- Yoy may use them as `Log.info`, `Log.error` etc. if you imported
+-- the module qualified with the corresponding alias.
 debug, info, warn, error :: (GHC.HasCallStack, MonadLogger m) => T.Text -> m ()
 debug = GHC.withFrozenCallStack $ logCapturingCallStack Debug
 info = GHC.withFrozenCallStack $ logCapturingCallStack Info
-warn = GHC.withFrozenCallStack $logCapturingCallStack Warning
+warn = GHC.withFrozenCallStack $ logCapturingCallStack Warning
 error = GHC.withFrozenCallStack $ logCapturingCallStack Error
 
 logCapturingCallStack :: (GHC.HasCallStack, MonadLogger m) => Severity -> T.Text -> m ()

--- a/src/Ext/Logger.hs
+++ b/src/Ext/Logger.hs
@@ -35,8 +35,6 @@ data Severity = Debug | Info | Warning | Error
 
 newtype CallStack = CallStack {unCallStack :: GHC.CallStack}
 
--- Yoy may use them as `Log.info`, `Log.error` etc. if you imported
--- the module qualified with the corresponding alias.
 logDebug, logInfo, logWarn, logError :: (GHC.HasCallStack, MonadLogger m) => T.Text -> m ()
 logDebug = GHC.withFrozenCallStack $ logCapturingCallStack Debug
 logInfo = GHC.withFrozenCallStack $ logCapturingCallStack Info

--- a/src/Ext/Logger.hs
+++ b/src/Ext/Logger.hs
@@ -19,9 +19,9 @@ import qualified Data.Text as T
 import qualified GHC.Stack as GHC
 import Prelude hiding (error)
 
--- | Use the type instead of 'MonadLogger' to pass the logger monad
--- constraint. This is necessary to capture the caller function name
--- within the GHC call stack.
+-- | You should generally prefer using this type as a constraint
+-- instead of 'MonadLogger' to enable logging. This is necessary to
+-- capture the caller function name within the GHC call stack.
 type WithLog m = (GHC.HasCallStack, MonadLogger m)
 
 class Monad m => MonadLogger m where

--- a/src/Ext/Logger/Colog.hs
+++ b/src/Ext/Logger/Colog.hs
@@ -1,21 +1,19 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Ext.Logger.Colog
-  ( module Export,
-    fieldMapIO,
-    fieldMapM,
-    fmtRichMessage,
+  ( LoggerT (..),
+    runWithAction,
     mkLogActionIO,
-    logFlush,
     setLineBuffering,
   )
 where
 
-import Colog as Export
+import qualified Colog
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans (liftIO)
 import Data.Aeson ((.=))
@@ -26,67 +24,84 @@ import qualified Data.Text as T
 import qualified Data.Time as Time
 import qualified Data.TypeRepMap as TM
 import qualified Ext.Data.Time as Clock
+import qualified Ext.Logger as Log
 import qualified Ext.Logger.Config as Conf
 import System.IO
   ( BufferMode (LineBuffering),
-    Handle,
-    hFlush,
     hSetBuffering,
     stdout,
   )
 
-type instance FieldType "timestamp" = Time.UTCTime
+-- | This is an instance of 'MonadLogger' based on 'Colog'.
+newtype LoggerT m a = LoggerT {runLoggerT :: Colog.LoggerT Colog.Message m a}
+  deriving (Functor, Applicative, Monad)
 
-type instance FieldType "appInstanceName" = T.Text
+instance MonadIO m => Log.MonadLogger (LoggerT m) where
+  logMessage = cologLogMessage
 
-fieldMapM :: Clock.MonadClock m => Conf.LoggerConfig -> FieldMap m
-fieldMapM conf = timestampedFieldMapM <> fieldMap conf
+instance MonadIO m => MonadIO (LoggerT m) where
+  liftIO = LoggerT . liftIO
 
-fieldMapIO :: MonadIO m => Conf.LoggerConfig -> FieldMap m
+cologLogMessage :: MonadIO m => Log.Severity -> Log.CallStack -> T.Text -> LoggerT m ()
+cologLogMessage severity callSite messageText = LoggerT $ Colog.logMsg cologMsg
+  where
+    cologMsg =
+      Colog.Msg
+        { msgSeverity = cologSeverityFromSeverity severity,
+          msgText = messageText,
+          msgStack = Log.unCallStack callSite
+        }
+
+cologSeverityFromSeverity :: Log.Severity -> Colog.Severity
+cologSeverityFromSeverity = \case
+  Log.Debug -> Colog.Debug
+  Log.Info -> Colog.Info
+  Log.Warning -> Colog.Warning
+  Log.Error -> Colog.Error
+
+runWithAction :: Monad m => Colog.LogAction m Colog.Message -> LoggerT m a -> m a
+runWithAction action = Colog.usingLoggerT action . runLoggerT
+
+type instance Colog.FieldType "timestamp" = Time.UTCTime
+
+type instance Colog.FieldType "appInstanceName" = T.Text
+
+fieldMapIO :: MonadIO m => Conf.LoggerConfig -> Colog.FieldMap m
 fieldMapIO conf = timestampedFieldMapIO <> fieldMap conf
-
-timestampedFieldMapM ::
-  forall m.
-  Clock.MonadClock m =>
-  FieldMap m
-timestampedFieldMapM = [#timestamp Clock.getCurrentTime]
 
 timestampedFieldMapIO ::
   forall m.
   MonadIO m =>
-  FieldMap m
+  Colog.FieldMap m
 timestampedFieldMapIO = [#timestamp Clock.now]
 
-fieldMap :: Monad m => Conf.LoggerConfig -> FieldMap m
+fieldMap :: Monad m => Conf.LoggerConfig -> Colog.FieldMap m
 fieldMap Conf.LoggerConfig {..} = [#appInstanceName (pure appInstanceName)]
 
-fmtRichMessage :: Monad m => RichMsg m Message -> m BS.ByteString
-fmtRichMessage RichMsg {richMsgMsg = Msg {..}, ..} = do
-  timestamp <- extractField $ TM.lookup @"timestamp" richMsgMap
-  appInstanceName <- extractField $ TM.lookup @"appInstanceName" richMsgMap
+fmtRichMessage :: Monad m => Colog.RichMsg m Colog.Message -> m BS.ByteString
+fmtRichMessage Colog.RichMsg {richMsgMsg = Colog.Msg {..}, ..} = do
+  timestamp <- Colog.extractField $ TM.lookup @"timestamp" richMsgMap
+  appInstanceName <- Colog.extractField $ TM.lookup @"appInstanceName" richMsgMap
   let logObj =
         J.object
           [ "timestamp" .= timestamp,
             "appInstanceName" .= appInstanceName,
             "severity" .= show msgSeverity,
-            "trace" .= showSourceLoc msgStack,
+            "trace" .= Colog.showSourceLoc msgStack,
             "message" .= msgText
           ]
   pure $ LBS.toStrict $ J.encode logObj
 
-mkLogActionIO :: MonadIO m => Conf.LoggerConfig -> LogAction m Message
+mkLogActionIO :: MonadIO m => Conf.LoggerConfig -> Colog.LogAction m Colog.Message
 mkLogActionIO conf@Conf.LoggerConfig {..} =
-  filterBySeverity logLevel msgSeverity $
-    upgradeMessageAction (fieldMapIO conf) $
-      cmapM fmtRichMessage stdoutLogger
+  Colog.filterBySeverity (cologSeverityFromSeverity logLevel) Colog.msgSeverity $
+    Colog.upgradeMessageAction (fieldMapIO conf) $
+      Colog.cmapM fmtRichMessage stdoutLogger
   where
     stdoutLogger =
       if logToStdout
-        then logByteStringStdout
+        then Colog.logByteStringStdout
         else mempty
-
-logFlush :: MonadIO m => Handle -> LogAction m a
-logFlush handle = LogAction $ const $ liftIO $ hFlush handle
 
 setLineBuffering :: MonadIO m => m ()
 setLineBuffering = liftIO $ hSetBuffering stdout LineBuffering

--- a/src/Ext/Logger/Config.hs
+++ b/src/Ext/Logger/Config.hs
@@ -3,8 +3,8 @@ module Ext.Logger.Config
   )
 where
 
-import qualified Colog as Log
 import qualified Data.Text as T
+import qualified Ext.Logger as Log
 
 data LoggerConfig = LoggerConfig
   { appInstanceName :: T.Text,

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -9,15 +9,15 @@ import AppName.Domain.PhoneVerification (UncheckedPhone (UncheckedPhone), checkP
 import AppName.Gateways.Database (withDbPoolDebug)
 import AppName.Gateways.Database.Tables.User (createUserRecord, loadUserById)
 import AppName.Server (runDevServer)
-import qualified Colog as Log
 import Control.Monad.IO.Unlift (MonadIO, liftIO)
 import Database.Persist.Postgresql
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger as Log
+import qualified Ext.Logger.Colog as CologAdapter
 import qualified Ext.Logger.Config as Log
 
 runDefaultExample :: IO ()
 runDefaultExample =
-  Log.usingLoggerT (Log.mkLogActionIO logConf) $ do
+  CologAdapter.runWithAction (CologAdapter.mkLogActionIO logConf) $ do
     config <- liftIO C.retrieveConfig
     runLogExample
     runDBExample config
@@ -25,9 +25,9 @@ runDefaultExample =
 
 runServer :: IO ()
 runServer =
-  Log.usingLoggerT (Log.mkLogActionIO logConf) $ do
+  CologAdapter.runWithAction (CologAdapter.mkLogActionIO logConf) $ do
     runLogExample
-    Log.logDebug "starting server"
+    Log.debug "starting server"
     liftIO runDevServer
 
 logConf :: Log.LoggerConfig
@@ -52,8 +52,7 @@ runDBExample config =
       liftIO $ print user
       pure ()
 
--- type WithLog env msg m = (MonadReader env m, HasLog env msg m)
-runLogExample :: Log.WithLog env Log.Message m => m ()
+runLogExample :: Log.WithLog m => m ()
 runLogExample = do
-  Log.logInfo "Starting application..."
-  Log.logDebug "Here is how we work!"
+  Log.info "Starting application..."
+  Log.debug "Here is how we work!"

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -27,7 +27,7 @@ runServer :: IO ()
 runServer =
   CologAdapter.runWithAction (CologAdapter.mkLogActionIO logConf) $ do
     runLogExample
-    Log.debug "starting server"
+    Log.logDebug "starting server"
     liftIO runDevServer
 
 logConf :: Log.LoggerConfig
@@ -54,5 +54,5 @@ runDBExample config =
 
 runLogExample :: Log.WithLog m => m ()
 runLogExample = do
-  Log.info "Starting application..."
-  Log.debug "Here is how we work!"
+  Log.logInfo "Starting application..."
+  Log.logDebug "Here is how we work!"

--- a/test/PhoneVerification.hs
+++ b/test/PhoneVerification.hs
@@ -27,7 +27,7 @@ import Data.Proxy
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
-import qualified Ext.Logger.Colog as Log
+import qualified Ext.Logger.Colog as CologAdapter
 import Network.HTTP.Types (Header, methodPost)
 import Network.Wai
 import Network.Wai.Test (SResponse)
@@ -92,8 +92,8 @@ mkApp onSendCode (MockUser userId) = do
   impl <- phoneVerificationAPI defParams mockExternals
   pure $ serve api $ hoistServer api hoistTestServer impl
 
-hoistTestServer :: Log.LoggerT Log.Message IO x -> Handler x
-hoistTestServer = Handler . ExceptT . try . Log.usingLoggerT mempty
+hoistTestServer :: CologAdapter.LoggerT IO x -> Handler x
+hoistTestServer = Handler . ExceptT . try . CologAdapter.runWithAction mempty
 
 jsonHeaders :: [Header]
 jsonHeaders = [("Content-Type", "application/json")]


### PR DESCRIPTION
Сделал тайпкласс `MonadLogger`, задуманный как интерфейс логгера, независимый от конкретной реализации. Спрятал большинство обращений к `colog` за ним. Далее я буду заменять `colog` на `katip`, что будет значительно легче с новым интерфейсом.

Прежде чем ревьюить, просьба смержить #29. Это уменьшит дифф.